### PR TITLE
add sorting of the added keys

### DIFF
--- a/delta.js
+++ b/delta.js
@@ -26,15 +26,6 @@ const unimplemented = {
         }
     }
 
-function sort(a, b) {
-    if (!a.key || !b.key) { console.log(a,'\n', b)}
-   let one = a.key.match(/bcd ::: (\w)*/)[0].replace("bcd ::: ", "")
-   let two = b.key.match(/bcd ::: (\w)*/)[0].replace("bcd ::: ", "")
-   
-   if (one < two) { return -1; }
-   if (two > one) { return +1; }
-   return 0;  
-}
 
 function union(setA, setB) {
   const _union = new Set(setA);
@@ -100,7 +91,6 @@ function delta (bcdObjA, bcdObjB) {
         if (inA && !inB) {
             out.removed.push(key)
         } else if (!inA && inB) {
-            //console.log("added ", key)
             out.added.push(key)
         }
         let hasChanges = deltaSupport(key, past, cur, out)
@@ -109,7 +99,14 @@ function delta (bcdObjA, bcdObjB) {
         }
     }
 
-    out.addedImplementations.sort(sort)
+    out.addedImplementations.sort((a, b) => {
+       let one = a.key.match(/bcd ::: (\w)*/)[0].replace("bcd ::: ", "")
+       let two = b.key.match(/bcd ::: (\w)*/)[0].replace("bcd ::: ", "")
+       
+       if (one < two) { return -1; }
+       if (two > one) { return +1; }
+       return 0;  
+    })
 
     return out
 }

--- a/delta.js
+++ b/delta.js
@@ -26,7 +26,6 @@ const unimplemented = {
         }
     }
 
-
 function union(setA, setB) {
   const _union = new Set(setA);
   for (const elem of setB) {

--- a/delta.js
+++ b/delta.js
@@ -26,6 +26,16 @@ const unimplemented = {
         }
     }
 
+function sort(a, b) {
+    if (!a.key || !b.key) { console.log(a,'\n', b)}
+   let one = a.key.match(/bcd ::: (\w)*/)[0].replace("bcd ::: ", "")
+   let two = b.key.match(/bcd ::: (\w)*/)[0].replace("bcd ::: ", "")
+   
+   if (one < two) { return -1; }
+   if (two > one) { return +1; }
+   return 0;  
+}
+
 function union(setA, setB) {
   const _union = new Set(setA);
   for (const elem of setB) {
@@ -90,6 +100,7 @@ function delta (bcdObjA, bcdObjB) {
         if (inA && !inB) {
             out.removed.push(key)
         } else if (!inA && inB) {
+            //console.log("added ", key)
             out.added.push(key)
         }
         let hasChanges = deltaSupport(key, past, cur, out)
@@ -97,6 +108,9 @@ function delta (bcdObjA, bcdObjB) {
         	out.changed[key] = cur[key]
         }
     }
+
+    out.addedImplementations.sort(sort)
+
     return out
 }
 


### PR DESCRIPTION
We need some tests for this, but I debugged the issue where we were having N copies of /api or /css and I didn't see any reason that this would have been for reasons we speculated previously (like, it was really in web extensions) - it does seem that somehow the might be getting mixed up.  If it's just that, then this solves the problem by sorting the items by their keys so they're kept together)..