### PR TITLE
one possible solution for #43

### DIFF
--- a/run.js
+++ b/run.js
@@ -31,7 +31,7 @@ let updatedDate = new Date(data.__meta.timestamp || Date.now())
 let latestReleaseDate = new Date(bookkeeping.latest.timestamp)
 
 let deltaInDays = Math.round((updatedDate - latestReleaseDate  ) /  86400000)
-let calendarDeltaInDays = Math.round((updatedDate - calendarDeltaInDays) / 86400000)
+let calendarDeltaInDays = Math.round((updatedDate - new Date()) / 86400000)
 
 console.log("meta:", JSON.stringify(data.__meta))
 console.log("updated %s, latest %s", updatedDate, latestReleaseDate)

--- a/run.js
+++ b/run.js
@@ -26,17 +26,22 @@ let data = await resp.json()
 
 console.log(`we have the new one:`) 
 
-// we have the new one!
+// we have the new one!document.querySelectorAll('[datetime]').forEach(item => console.log(item.getAttribute('datetime')) )
 let updatedDate = new Date(data.__meta.timestamp || Date.now())
-let latestDate = new Date(bookkeeping.latest.timestamp)
+let latestReleaseDate = new Date(bookkeeping.latest.timestamp)
 
-let deltaInDays = Math.round((updatedDate - latestDate  ) /  86400000)
+let deltaInDays = Math.round((updatedDate - latestReleaseDate  ) /  86400000)
+let calendarDeltaInDays = Math.round((updatedDate - calendarDeltaInDays) / 86400000)
 
 console.log("meta:", JSON.stringify(data.__meta))
-console.log("updated %s, latest %s", updatedDate, latestDate)
+console.log("updated %s, latest %s", updatedDate, latestReleaseDate)
 console.log(`It's been ${deltaInDays} days since then.`)
 	
-if((updatedDate > latestDate) && (deltaInDays >= 5)){
+if(
+	((updatedDate > latestReleaseDate) && (deltaInDays >= 5))
+	||
+	calendarDeltaInDays > 6
+  ) {
 	console.log("I think I should update")
 
 	let dateParts = updatedDate.toDateString().split(' ')


### PR DESCRIPTION
Ok, this is the _easiest_ "almost solution" to #43 which should just force it to run if it has been 7 days or more since it ran successfully last time. That would mean that when 43 was written we would have gotten a report on the 9th for the release that happened on the 7th - which is pretty normal in how we do it now.  But then we wouldn't get another one for at least 5 days, but no more than 7.

The only other alternative that I can think of is to force runs to always be _generated_ on mondays with whatever the latest release data is, even if it happens to be 6 days old, and just somehow adjust how it's displayed. However, if we do that I think we should write a script to rewrite all of the historical ones we have so they all look like that.  I'm not sure how much effort that would take, maybe not too bad, but definitely some 
