### PR TITLE
prevent rerunning the same report and reporting the same date

### DIFF
--- a/format.js
+++ b/format.js
@@ -68,7 +68,8 @@ function formatSummary(delta, data) {
 		removedImplementations: delta.removedImplementations,
 		backfilledImplementationsCt: backfilledImplementationsCt,
 		backfilledImplementations: delta.backfilledImplementations,
-		allImplementationsCt: addedFeaturesCt + removedFeaturesCt + backfilledImplementationsCt
+		allImplementationsCt: addedFeaturesCt + removedFeaturesCt + backfilledImplementationsCt,
+		hasNewData: delta.hasNewData
 	})
 }
 
@@ -103,6 +104,7 @@ function formatCompleted(delta, data) {
 		laterReleaseDateTime: delta.__meta[0].newer.releaseDate,
 		reportDate: reportDate,
 		permalink: delta.permalink + ".html",
+		hasNewData: delta.hasNewData,
 		completedCt: ct,
 		completedImplementations: complete
 	})

--- a/index.js
+++ b/index.js
@@ -97,10 +97,11 @@ function run(o, l, f='') {
   let name = f 
 
   data.__meta = [{
-      generatedOn: name, 
+      generatedOn: name,
       older: { releaseDate: fromDate },
       newer: { releaseDate: toDate }
   }]
+  data.hasNewData = !utils.areSameDate(fromDate, toDate),
   data.addedFeatures = toTopicsFromStrings(data.added)
   data.removedFeatures = toTopicsFromStrings(data.removed)
   data.backfilledImplementations = toTopicsFromObjects(data.backfilledImplementations)

--- a/run.js
+++ b/run.js
@@ -12,6 +12,7 @@ function isTodayMonday() {
   return today.getDay() === 1;
 }
 
+
 console.log("checking...", today)
 JSDOM
   .fromURL("https://github.com/mdn/browser-compat-data/releases", {})
@@ -55,7 +56,7 @@ JSDOM
       fs.writeFileSync(`./store/${filename}`, JSON.stringify(data), 'utf8')
 
 
-      if (isTodayMonday()) {
+      if (isTodayMonday() && !utils.areSameDate(latestReleaseDate, updatedDate)) {
         //update bookkeeping values
         bookkeeping.previous = bookkeeping.latest
         bookkeeping.latest = {
@@ -82,7 +83,6 @@ JSDOM
     } else {
       //rerun index stuff with those
       if (isTodayMonday()) {
-
         console.log("No updates to the store, but we'll write a new report...")
         index(
           bookkeeping.latest.file,

--- a/templates/baseline.handlebars
+++ b/templates/baseline.handlebars
@@ -15,56 +15,61 @@
 </head>
 <body>
     <h1>BCD New Baselines Report <time>{{reportDate}}</time></h1>
-    <p>
-    <strong>New baseline implementations</strong>
-    <span>from available bcd releases in this timeframe: <time title="{{olderReleaseDateTime}}">{{olderReleaseDate}}</time></span>
-    <span>to <time title="{{laterReleaseDateTime}}">{{laterReleaseDate}}</time></span> <a href="{{permalink}}" title="permalink">🔗</a>
-    </p>
-
-    {{#unless completedCt}}
-    <p>No new Baseline implementations to report 🙁</p>
+    {{#unless hasNewData}}
+        <strong>There are no new BCD releases in this timeframe.</strong>
     {{/unless}}
+    {{#if hasNewData}}
+        <p>
+        <strong>New baseline implementations</strong>
+        <span>from available bcd releases in this timeframe: <time title="{{olderReleaseDateTime}}">{{olderReleaseDate}}</time></span>
+        <span>to <time title="{{laterReleaseDateTime}}">{{laterReleaseDate}}</time></span> <a href="{{permalink}}" title="permalink">🔗</a>
+        </p>
 
-    {{#if completedCt}}
-      <p>{{completedCt}} new Baseline {{pluralize completedCt 'implementation'}}</p>
-      <section class="added implementations">
-        {{#each completedImplementations}}
-          <h4>{{@key}}</h4>
-          <ol>
-            {{#each this}}
-              <li>
-                {{#unless (mdnLink this)}}
-                  <span>{{formatFeatureStr key topic}}
-                  	{{#if (specLink this)}}
-                  	<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
-                  	{{/if}}
-                    {{#if status.deprecated}}
-                      (⚠️ deprecated)
+        {{#unless completedCt}}
+        <p>No new Baseline implementations to report 🙁</p>
+        {{/unless}}
+
+        {{#if completedCt}}
+          <p>{{completedCt}} new Baseline {{pluralize completedCt 'implementation'}}</p>
+          <section class="added implementations">
+            {{#each completedImplementations}}
+              <h4>{{@key}}</h4>
+              <ol>
+                {{#each this}}
+                  <li>
+                    {{#unless (mdnLink this)}}
+                      <span>{{formatFeatureStr key topic}}
+                      	{{#if (specLink this)}}
+                      	<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
+                      	{{/if}}
+                        {{#if status.deprecated}}
+                          (⚠️ deprecated)
+                        {{/if}}
+                      </span>
+                    {{/unless}}
+
+          
+
+                    {{#if (mdnLink this)}}
+                      <span>
+                        <a href="{{mdnLink this}}">{{formatFeatureStr key topic}}</a>
+                        {{#if status.deprecated}}
+                          (⚠️ deprecated)
+                        {{/if}}
+                      </span>
                     {{/if}}
-                  </span>
-                {{/unless}}
+                    
+                    <b><br></b> 
+                    <span class="browsers">Added to <strong>{{addedImplementations}}</strong></span> 
+                    <b>&nbsp;➞&nbsp;</b>
+                    <span class="ni{{totalImplementations}} engines"><strong>{{totalImplementations}} of 3</strong> engines</span>
 
-      
-
-                {{#if (mdnLink this)}}
-                  <span>
-                    <a href="{{mdnLink this}}">{{formatFeatureStr key topic}}</a>
-                    {{#if status.deprecated}}
-                      (⚠️ deprecated)
-                    {{/if}}
-                  </span>
-                {{/if}}
-                
-                <b><br></b> 
-                <span class="browsers">Added to <strong>{{addedImplementations}}</strong></span> 
-                <b>&nbsp;➞&nbsp;</b>
-                <span class="ni{{totalImplementations}} engines"><strong>{{totalImplementations}} of 3</strong> engines</span>
-
-              </li>
+                  </li>
+                {{/each}}
+              </ol>
             {{/each}}
-          </ol>
-        {{/each}}
-      </section>
+          </section>
+        {{/if}}
     {{/if}}
   <footer>
   	<p>

--- a/templates/weekly.handlebars
+++ b/templates/weekly.handlebars
@@ -17,171 +17,176 @@
 
   <h1>BCD Changes Report, <time>{{reportDate}}</time></h1>
 	<p>
-	<strong>Summary of BCD changes</strong>
-	<span>from available bcd releases in this timeframe <time title="{{olderReleaseDateTime}}">{{olderReleaseDate}}</time></span>
-	<span>to <time title="{{laterReleaseDateTime}}">{{laterReleaseDate}}</time></span> <a href="{{permalink}}" title="permalink">🔗</a>
-	</p>
+  {{#unless hasNewData}}
+    <strong>There are no new BCD releases in this timeframe.</strong>
+  {{/unless}}
+  {{#if hasNewData}}
+  	<strong>Summary of BCD changes</strong>
+  	<span>from available BCD releases in this timeframe: <time title="{{olderReleaseDateTime}}">{{olderReleaseDate}}</time></span>
+  	<span>to <time title="{{laterReleaseDateTime}}">{{laterReleaseDate}}</time></span> <a href="{{permalink}}" title="permalink">🔗</a>
+  	</p>
 
-  <h2>Browser Support Changes: +{{addedImplmentationsCt}}, -{{removedImplementationsCt}}</h2>
+    <h2>Browser Support Changes: +{{addedImplmentationsCt}}, -{{removedImplementationsCt}}</h2>
 
-    {{#if addedImplmentationsCt}}
-      <h3>Support increases ({{addedImplmentationsCt}})</h3>
-      <section class="added implementations">
-        {{#each addedImplementations}}
-          <h4>{{@key}}</h4>
-          <ol>
-            {{#each this}}
-              <li>
-                {{#unless (mdnLink this)}}
-                  <span>{{formatFeatureStr key topic}}
-                  	{{#if (specLink this)}}
-                  	<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
-                  	{{/if}}
+      {{#if addedImplmentationsCt}}
+        <h3>Support increases ({{addedImplmentationsCt}})</h3>
+        <section class="added implementations">
+          {{#each addedImplementations}}
+            <h4>{{@key}}</h4>
+            <ol>
+              {{#each this}}
+                <li>
+                  {{#unless (mdnLink this)}}
+                    <span>{{formatFeatureStr key topic}}
+                    	{{#if (specLink this)}}
+                    	<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
+                    	{{/if}}
+                      {{#if status.deprecated}}
+                        (⚠️ deprecated)
+                      {{/if}}
+                  </span>
+                  {{/unless}}
+
+                  {{#if (mdnLink this)}}
+                    <span><a href="{{mdnLink this}}">{{formatFeatureStr key topic}}</a>
                     {{#if status.deprecated}}
                       (⚠️ deprecated)
                     {{/if}}
-                </span>
-                {{/unless}}
-
-                {{#if (mdnLink this)}}
-                  <span><a href="{{mdnLink this}}">{{formatFeatureStr key topic}}</a>
-                  {{#if status.deprecated}}
-                    (⚠️ deprecated)
+                    </span>
                   {{/if}}
+                  
+                  <b><br></b> 
+                  <span class="browsers">Added to <strong>{{addedImplementations}}</strong></span> 
+                  <b>&nbsp;➞&nbsp;</b>
+                  <span class="ni{{totalImplementations}} engines"><strong>{{totalImplementations}} of 3</strong> engines</span>
+
+                </li>
+              {{/each}}
+            </ol>
+          {{/each}}
+        </section>
+      {{/if}}
+
+      {{#if removedImplementationsCt}}
+        <h3>Support decreases ({{removedImplementationsCt}})</h3>
+        <section class="removed implementations">
+          {{#each removedImplementations}}
+            <h4>{{@key}}</h4>
+            <ol>
+              {{#each this}}
+                <li>
+                  {{#unless (mdnLink this)}}
+                    <span>{{formatFeatureStr key topic}}
+                    	{{#if (specLink this)}}
+                    	<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
+                    	{{/if}}
                   </span>
-                {{/if}}
-                
-                <b><br></b> 
-                <span class="browsers">Added to <strong>{{addedImplementations}}</strong></span> 
-                <b>&nbsp;➞&nbsp;</b>
-                <span class="ni{{totalImplementations}} engines"><strong>{{totalImplementations}} of 3</strong> engines</span>
+                  {{/unless}}
 
-              </li>
-            {{/each}}
-          </ol>
-        {{/each}}
-      </section>
-    {{/if}}
+                  {{#if (mdnLink this)}}
+                    <a href="{{mdnLink this}}">{{formatFeatureStr key topic}}</a>
+                  {{/if}}
 
-    {{#if removedImplementationsCt}}
-      <h3>Support decreases ({{removedImplementationsCt}})</h3>
-      <section class="removed implementations">
-        {{#each removedImplementations}}
+                  
+                  <b><br></b> 
+                  <span class="browsers">Removed from <strong>{{removedImplementations}}</strong></span> 
+                  <b>&nbsp;➞&nbsp;</b>
+                  <span class="ni{{totalImplementations}} engines"><strong>{{totalImplementations}} of 3</strong> engines</span>
+
+                </li>
+              {{/each}}
+            </ol>
+          {{/each}}
+        </section>
+      {{/if}}
+
+    </section>
+
+
+    <h2>BCD Metadata Changes: {{allImplementationsCt}}</h2>
+    <details>
+      <summary>Show all {{ allImplementationsCt }} changes</summary>
+      <p class="info"><strong>Note:</strong> The following represent changes to BCD metadata keys
+        in the reported time period.  Keys are not implementations, and they don't represent commitments toward implementation, etc.  A new key occuring is perhaps a signal that some implementer was serious enough to add the key.  Many of the features that are 'removed' are usually just 'moved' or 'renamed', but we don't have great ways to highlight that.
+      </p>
+
+      {{#if backfilledImplementationsCt}}
+        <h3>Backfilled entries ({{backfilledImplementationsCt}})</h3>
+      <p class="info">The entries in this section saw support information change since the report on  {{ olderReleaseDate }}, but all the supported browser versions given were more than a couple of months old.  Typically, these are cases of support information being updated long after the support actually landed in a browser, but nobody ever updated the BCD entry.
+      </p>
+        <section class="backfilled implementations">
+          {{#each backfilledImplementations}}
+            <h4>{{@key}}</h4>
+            <ol>
+              {{#each this}}
+                <li>
+                  {{#unless (mdnLink this)}}
+                    <span>{{formatFeatureStr key topic}}
+                    	{{#if (specLink this)}}
+                    	<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
+                    	{{/if}}
+                  </span>
+                  {{/unless}}
+
+                  {{#if (mdnLink this)}}
+                    <a href="{{mdnLink this}}">{{formatFeatureStr key topic}}</a>
+                  {{/if}}
+                  
+                  <b><br></b> 
+                  <span class="browsers">Backfilled from <strong>{{backfilledImplementations}}</strong></span> 
+                  <b>&nbsp;➞&nbsp;</b>
+                  <span class="ni{{totalImplementations}} engines"><strong>{{totalImplementations}} of 3</strong> engines</span>
+
+                </li>
+              {{/each}}
+            </ol>
+          {{/each}}
+        </section>
+      {{/if}}
+      
+      <h3>New entries ({{addedFeaturesCt}})</h3>
+      {{#unless addedFeaturesCt}}
+        No features were added to BCD in this time period.
+      {{/unless}}
+      {{#if addedFeaturesCt}}
+      <p class="info">The entries in this section were not found in BCD on {{ olderReleaseDate }}, but are now present. These usually do not have any support information attached to them, and often have no corresponding MDN page. Sometimes, entries that appear here also appear in the next section (“Removed BCD entries”) because of a Working Group deciding on a rename.
+      </p>
+        {{#each addedFeatures}}
           <h4>{{@key}}</h4>
           <ol>
             {{#each this}}
-              <li>
-                {{#unless (mdnLink this)}}
-                  <span>{{formatFeatureStr key topic}}
-                  	{{#if (specLink this)}}
-                  	<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
-                  	{{/if}}
-                </span>
-                {{/unless}}
-
-                {{#if (mdnLink this)}}
-                  <a href="{{mdnLink this}}">{{formatFeatureStr key topic}}</a>
-                {{/if}}
-
-                
-                <b><br></b> 
-                <span class="browsers">Removed from <strong>{{removedImplementations}}</strong></span> 
-                <b>&nbsp;➞&nbsp;</b>
-                <span class="ni{{totalImplementations}} engines"><strong>{{totalImplementations}} of 3</strong> engines</span>
-
+              <li>{{formatFeatureStr this}}
+  							{{#if (specLink this)}}
+  							<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
+  							{{/if}}
               </li>
             {{/each}}
           </ol>
-        {{/each}}
-      </section>
-    {{/if}}
+        {{/each}} 
+      {{/if}}
 
-  </section>
-
-
-  <h2>BCD Metadata Changes: {{allImplementationsCt}}</h2>
-  <details>
-    <summary>Show all {{ allImplementationsCt }} changes</summary>
-    <p class="info"><strong>Note:</strong> The following represent changes to BCD metadata keys
-      in the reported time period.  Keys are not implementations, and they don't represent commitments toward implementation, etc.  A new key occuring is perhaps a signal that some implementer was serious enough to add the key.  Many of the features that are 'removed' are usually just 'moved' or 'renamed', but we don't have great ways to highlight that.
-    </p>
-
-    {{#if backfilledImplementationsCt}}
-      <h3>Backfilled entries ({{backfilledImplementationsCt}})</h3>
-    <p class="info">The entries in this section saw support information change since the report on  {{ olderReleaseDate }}, but all the supported browser versions given were more than a couple of months old.  Typically, these are cases of support information being updated long after the support actually landed in a browser, but nobody ever updated the BCD entry.
-    </p>
-      <section class="backfilled implementations">
-        {{#each backfilledImplementations}}
+      <h3>Removed entries ({{removedFeaturesCt}})</h3>
+      {{#unless removedFeaturesCt}}
+        No features were removed from bcd in this time period
+      {{/unless}}
+      {{#if removedFeaturesCt}}
+      <p class="info">The entries in this section were found in BCD on {{ olderReleaseDate }}, but are no longer present. The reasons for this removal can be anything from an experimental proposal that was never supported to a property or value being renamed to something else.
+      </p>
+        {{#each removedFeatures}}
           <h4>{{@key}}</h4>
           <ol>
             {{#each this}}
-              <li>
-                {{#unless (mdnLink this)}}
-                  <span>{{formatFeatureStr key topic}}
-                  	{{#if (specLink this)}}
-                  	<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
-                  	{{/if}}
-                </span>
-                {{/unless}}
-
-                {{#if (mdnLink this)}}
-                  <a href="{{mdnLink this}}">{{formatFeatureStr key topic}}</a>
-                {{/if}}
-                
-                <b><br></b> 
-                <span class="browsers">Backfilled from <strong>{{backfilledImplementations}}</strong></span> 
-                <b>&nbsp;➞&nbsp;</b>
-                <span class="ni{{totalImplementations}} engines"><strong>{{totalImplementations}} of 3</strong> engines</span>
-
+              <li>{{formatFeatureStr this}}
+  							{{#if (specLink this)}}
+  							<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
+  							{{/if}}
               </li>
             {{/each}}
           </ol>
-        {{/each}}
-      </section>
-    {{/if}}
-    
-    <h3>New entries ({{addedFeaturesCt}})</h3>
-    {{#unless addedFeaturesCt}}
-      No features were added to BCD in this time period.
-    {{/unless}}
-    {{#if addedFeaturesCt}}
-    <p class="info">The entries in this section were not found in BCD on {{ olderReleaseDate }}, but are now present. These usually do not have any support information attached to them, and often have no corresponding MDN page. Sometimes, entries that appear here also appear in the next section (“Removed BCD entries”) because of a Working Group deciding on a rename.
-    </p>
-      {{#each addedFeatures}}
-        <h4>{{@key}}</h4>
-        <ol>
-          {{#each this}}
-            <li>{{formatFeatureStr this}}
-							{{#if (specLink this)}}
-							<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
-							{{/if}}
-            </li>
-          {{/each}}
-        </ol>
-      {{/each}} 
-    {{/if}}
-
-    <h3>Removed entries ({{removedFeaturesCt}})</h3>
-    {{#unless removedFeaturesCt}}
-      No features were removed from bcd in this time period
-    {{/unless}}
-    {{#if removedFeaturesCt}}
-    <p class="info">The entries in this section were found in BCD on {{ olderReleaseDate }}, but are no longer present. The reasons for this removal can be anything from an experimental proposal that was never supported to a property or value being renamed to something else.
-    </p>
-      {{#each removedFeatures}}
-        <h4>{{@key}}</h4>
-        <ol>
-          {{#each this}}
-            <li>{{formatFeatureStr this}}
-							{{#if (specLink this)}}
-							<a href="{{specLink this}}"><img src="../imgs/spec2.svg" alt="Spec link"></a>
-							{{/if}}
-            </li>
-          {{/each}}
-        </ol>
-      {{/each}} 
-    {{/if}}
-  </details>
+        {{/each}} 
+      {{/if}}
+    </details>
+  {{/if}}
   
   <footer>
   	<p>

--- a/utils.js
+++ b/utils.js
@@ -51,6 +51,10 @@ function findNextMonday(date, forward=false) {
     return result;
 }
 
+function areSameDate(date1, date2) {
+ return  date1.toDateString() == date2.toDateString();
+}
+
 
 exports.toISODateString = toISODateString
 exports.toShortDateString = toShortDateString
@@ -58,4 +62,5 @@ exports.stripFileExtension = stripFileExtension
 exports.jsonForDate = jsonForDate
 exports.findNextMonday = findNextMonday
 exports.dateFromISODateString = dateFromISODateString
+exports.areSameDate = areSameDate
 


### PR DESCRIPTION
This PR prevents duplicate running on the same day problem we discussed this morning.  If a release has already been used to generate the report, an update on that same day won't make it run again.

It also prevents a meaningless comparison being reported in the actual report and just says "there were no bcd releases in this time period".

This PR does NOT address how we will say something more clearly something about the report _dates_ and _releases_ 