### PR TITLE
add a new manual index which doesn't reason much

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Under normal operation, bcd-watch tracks the releases it's used in `/store/bookk
 The HTML files are generated with Handlebars templates which live in `/templates/`.
 
 Occasionally, if we change something about templating, we may run `reprocessAll.js`, which just looks at the date oriented release files in `/store/` and loops through a simulation of each Monday from then until now.
+
+You can manually re-run a scenario with `manual-index.js` providing two dates representing valid entries in /store
+  and an output date which is a monday, for example `node manual-index.js 2024-09-06 2024-09-20 2024-09-23`.
+

--- a/manual-index.js
+++ b/manual-index.js
@@ -2,39 +2,21 @@ const fs = require('fs')
 const index = require('./index.js').run
 const utils = require('./utils.js')
 
-const bookkeeping = JSON.parse(
-	fs.readFileSync('./store/bookkeeping.json', 'utf8')
-)
+if (process.argv.length !== 5) { 
+ console.error('Expected 3 date strings yyyy-mm-dd representing the starting diff date, the ending diff date (both must be in /store) and an output date (must be a monday)!'); 
+ process.exit(1); 
+} 
 
+outputDate = utils.dateFromISODateString(process.argv[4])
+if(outputDate.getDay() !== 1) {
+	console.error('the third argument (output date) must currently be a monday!'); 
+ 	process.exit(1); 
+}
 
-let today = new Date(),
-
-	// If today is monday, use today, otherwise fine previous monday
-	m = (today.getDay() == 1) ? today : utils.findPreviousMonday(today),
-	
-	previousReleaseDate = utils.dateFromISODateString(
-		utils.stripFileExtension(
-			bookkeeping.previous.file
-		)
-	),
-
-	latestReleaseDate = utils.dateFromISODateString(
-		utils.stripFileExtension(
-			bookkeeping.latest.file
-		)
-	),
-
-	diffReportDate = utils.findNextMonday(latestReleaseDate)
-
-	// if the relevant report day would be greater than today,
-	// the diff is just between latest and latest (ie, nothing)
-	if(diffReportDate < today) {
-		bookkeeping.previous = bookkeeping.latest
-	}
 
 //rerun index stuff with those
 index(
-	bookkeeping.previous.file, 
-	bookkeeping.latest.file, 
-	utils.toISODateString(m)
+	process.argv[2] + ".json", 
+	process.argv[3] + ".json", 
+	process.argv[4]
 )


### PR DESCRIPTION
Before releasing, we rewrote a bunch of stuff in the last month to (appear at least) to be based on Monday to Mondays.  This has caused a bunch of confusion especially as it can sometimes be run on mondays and it can need to be _re_ run on mondays, and sometimes updates also happen on mondays.  As such there is now some funky code which is patched in here and there at some places where it just doesn't make sense all 7 days of the week.  I feel like it needs to be cleaned up, so here is a simple OG-style way to specifically run the comparison of 2 jsons in store and output a specific file which currently has to be a monday and which you'll have to specify yourself.  This _at least_ gets us a basic thing, but really we should have a few simple commands that you can run for the basic scenarios probably, like "rerunLastReport" or something as one, for example. Today we can't exactly do that reliably because it's relying too much on the date it runs in the job and a relationship to the output file name.

reprocessAll works, but it's heavy-handed.

